### PR TITLE
Add Test Coverage Reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,9 @@ jobs:
         run: mix compile --warnings-as-errors
 
       - name: Run Tests
-        run: mix test
+        run: mix coveralls.json
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Diff Check
 
 [![ci](https://github.com/terenceponce/diff_check/actions/workflows/ci.yml/badge.svg)](https://github.com/terenceponce/diff_check/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/terenceponce/diff_check/graph/badge.svg?token=F692aysHWW)](https://codecov.io/gh/terenceponce/diff_check)
 
 ## Quick Start
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,15 @@ defmodule DiffCheck.MixProject do
       version: "0.0.0",
       elixir: "1.15.7",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test,
+        "coveralls.cobertura": :test
+      ]
     ]
   end
 
@@ -21,8 +29,7 @@ defmodule DiffCheck.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+      {:excoveralls, "0.18.0", only: :test}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,4 @@
+%{
+  "excoveralls": {:hex, :excoveralls, "0.18.0", "b92497e69465dc51bc37a6422226ee690ab437e4c06877e836f1c18daeb35da9", [:mix], [{:castore, "~> 1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "1109bb911f3cb583401760be49c02cbbd16aed66ea9509fc5479335d284da60b"},
+  "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},
+}


### PR DESCRIPTION
This adds excoveralls to produce test coverage reports.

This also integrates CodeCov.io into the CI run where coverage reports are uploaded into.