### PR TITLE
Disable printing to IO in tests

### DIFF
--- a/lib/diff_check.ex
+++ b/lib/diff_check.ex
@@ -2,7 +2,7 @@ defmodule DiffCheck do
   alias DiffCheck.BuildMatrix
   alias DiffCheck.PrintDiff
 
-  def main(args) do
+  def main(args, disable_printing \\ false) do
     case validate_args(args) do
       :ok ->
         [file1_path, file2_path] = args
@@ -14,10 +14,10 @@ defmodule DiffCheck do
         |> BuildMatrix.call(file2)
         |> PrintDiff.call(file1, file2)
         |> Enum.join("\n")
-        |> IO.write()
+        |> print_to_io(disable_printing)
 
       {:error, message} ->
-        IO.puts("Error: #{message}")
+        print_to_io("Error: #{message}", disable_printing)
         {:error, message}
     end
   end
@@ -34,5 +34,16 @@ defmodule DiffCheck do
       _ ->
         {:error, "You must provide exactly two arguments"}
     end
+  end
+
+  defp print_to_io(message, disable_printing) do
+    # coveralls-ignore-start
+    unless disable_printing do
+      IO.write(message)
+    end
+
+    # coveralls-ignore-stop
+
+    :ok
   end
 end

--- a/test/diff_check_test.exs
+++ b/test/diff_check_test.exs
@@ -6,14 +6,14 @@ defmodule DiffCheckTest do
     file1 = Path.expand("support/fixtures/test_response_1.json", __DIR__)
     file2 = Path.expand("support/fixtures/test_response_2.json", __DIR__)
 
-    assert DiffCheck.main([file1, file2]) == :ok
+    assert DiffCheck.main([file1, file2], true) == :ok
   end
 
   test "fails with non-existent files" do
-    assert DiffCheck.main(["foo", "bar"]) == {:error, "One or both files do not exist"}
+    assert DiffCheck.main(["foo", "bar"], true) == {:error, "One or both files do not exist"}
   end
 
   test "fails with incomplete arguments" do
-    assert DiffCheck.main([]) == {:error, "You must provide exactly two arguments"}
+    assert DiffCheck.main([], true) == {:error, "You must provide exactly two arguments"}
   end
 end


### PR DESCRIPTION
This adds an optional argument to the main class that allows printing to the IO to be disabled.

The motivation for doing this is to remove the noise when running tests.