### PR TITLE
Lint Main File

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -28,9 +28,7 @@
         excluded: [
           ~r"/_build/",
           ~r"/deps/",
-          ~r"/lib/diff_check.ex",
-          ~r"/test/support",
-          ~r"/test/diff_check_test.exs"
+          ~r"/test/support"
         ]
       },
       #

--- a/lib/diff_check.ex
+++ b/lib/diff_check.ex
@@ -1,14 +1,28 @@
 defmodule DiffCheck do
+  @moduledoc """
+  DiffCheck is a command-line tool that compares two files and prints the
+  differences between them.
+
+  The way this works is that it builds a 2D matrix of the two files by
+  computing for the longest subsequence between each files. It then prints
+  the differences between the two files by backtracking through the matrix.
+
+  The LCS implementation used is based on this Wikipedia article:
+
+  https://en.wikipedia.org/wiki/Longest_common_subsequence
+  """
+
   alias DiffCheck.BuildMatrix
   alias DiffCheck.PrintDiff
 
+  @spec main(args :: [String.t()], disable_printing :: boolean) :: :ok | {:error, String.t()}
   def main(args, disable_printing \\ false) do
     case validate_args(args) do
       :ok ->
         [file1_path, file2_path] = args
 
-        file1 = File.read!(file1_path) |> String.split("\n")
-        file2 = File.read!(file2_path) |> String.split("\n")
+        file1 = stringify_file(file1_path)
+        file2 = stringify_file(file2_path)
 
         file1
         |> BuildMatrix.call(file2)
@@ -45,5 +59,11 @@ defmodule DiffCheck do
     # coveralls-ignore-stop
 
     :ok
+  end
+
+  defp stringify_file(file_path) do
+    file_path
+    |> File.read!()
+    |> String.split("\n")
   end
 end

--- a/test/diff_check_test.exs
+++ b/test/diff_check_test.exs
@@ -1,6 +1,5 @@
 defmodule DiffCheckTest do
-  use ExUnit.Case
-  doctest DiffCheck
+  use ExUnit.Case, async: true
 
   test "works with valid arguments" do
     file1 = Path.expand("support/fixtures/test_response_1.json", __DIR__)


### PR DESCRIPTION
I just realized that the main file and its test are included in Credo's ignore list.

This fixes that oversight by removing the affected files from the ignore list and fixing all of the errors mentioned by Credo.